### PR TITLE
Support multiple account

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 435391edb5bc0930b383b67bf1a5e23752c0678b96b88dbbad82192c533a28fe
-updated: 2017-07-29T23:43:25.114130919+09:00
+hash: d84d4706d683a4eefa92dab2570425a9faa44188bf59f5916891b7fa2bd1dc03
+updated: 2017-08-08T19:19:11.918103459+09:00
 imports:
 - name: github.com/bitfinexcom/bitfinex-api-go
   version: 80112fc15e3577dc14f77262d57d40f1272d2637
@@ -32,6 +32,14 @@ imports:
   - codec
 - name: github.com/urfave/cli
   version: 4b90d79a682b4bf685762c7452db20f2a676ecb2
+- name: golang.org/x/net
+  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
+  subpackages:
+  - context
+- name: golang.org/x/sync
+  version: f52d1811a62927559de87708c8913c1650ce4f26
+  subpackages:
+  - errgroup
 - name: gopkg.in/jcelliott/turnpike.v2
   version: fd62c756857599590cc1f661bd3e4e2ecf25cfd8
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,6 @@ import:
 - package: github.com/gabu/moon
 - package: github.com/olekukonko/tablewriter
 - package: github.com/mattn/go-runewidth
+- package: golang.org/x/sync
+  subpackages:
+  - errgroup

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ func main() {
 	app.Version = "1.0.0"
 
 	flags := []cli.Flag{}
+
+	flags = append(flags, cli.StringSliceFlag{
+		Name:  "sort",
+		Usage: `sort method, "exchange", "symbol", btc", "value" are available. (default: btc)`,
+	})
+
 	for _, exchange := range supportedExchanges {
 		flags = append(flags, cli.StringFlag{
 			Name:  exchange,
@@ -67,8 +73,24 @@ func aggs(c *cli.Context) error {
 		}
 	}
 
+	sortm := c.StringSlice("sort")
 	sort.Slice(balances, func(i int, j int) bool {
-		return balances[i].Balance.BtcValue > balances[j].Balance.BtcValue
+		ib, jb := balances[i], balances[j]
+		for _, m := range sortm {
+			if m == "btc" && ib.Balance.BtcValue != jb.Balance.BtcValue {
+				return ib.Balance.BtcValue > jb.Balance.BtcValue
+			}
+			if m == "exchange" && ib.Exchange != jb.Exchange {
+				return ib.Exchange > jb.Exchange
+			}
+			if m == "symbol" && ib.Symbol != jb.Symbol {
+				return ib.Symbol > jb.Symbol
+			}
+			if m == "value" && ib.Balance.Amount != jb.Balance.Amount {
+				return ib.Balance.Amount > jb.Balance.Amount
+			}
+		}
+		return false
 	})
 
 	table := tablewriter.NewWriter(os.Stdout)

--- a/main.go
+++ b/main.go
@@ -84,16 +84,16 @@ func aggs(c *cli.Context) error {
 	sort.Sort(balances)
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Exchange", "Symbol", "BTC Value"})
+	table.SetHeader([]string{"Exchange", "Symbol", "Value", "BTC Value"})
 
 	total := 0.0
 	for _, b := range balances {
 		v, _ := strconv.ParseFloat(b.Balance.BtcValue, 64)
 		total += v
-		table.Append([]string{b.Exchange, b.Symbol, b.Balance.BtcValue})
+		table.Append([]string{b.Exchange, b.Symbol, b.Balance.Amount, b.Balance.BtcValue})
 	}
 
-	table.SetFooter([]string{"", "Total", moon.FormatFloat(total) + " BTC"})
+	table.SetFooter([]string{"", "Total", "", moon.FormatFloat(total) + " BTC"})
 	table.Render()
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -27,20 +27,6 @@ type Balance struct {
 	Balance  moon.Balance
 }
 
-type Balances []Balance
-
-func (b Balances) Len() int {
-	return len(b)
-}
-
-func (b Balances) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
-}
-
-func (b Balances) Less(i, j int) bool {
-	return b[i].Balance.BtcValue > b[j].Balance.BtcValue
-}
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "coinfolio"
@@ -68,8 +54,8 @@ func main() {
 }
 
 func aggs(c *cli.Context) error {
-	balances := Balances{}
 	var err error
+	balances := []Balance{}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -81,7 +67,9 @@ func aggs(c *cli.Context) error {
 		}
 	}
 
-	sort.Sort(balances)
+	sort.Slice(balances, func(i int, j int) bool {
+		return balances[i].Balance.BtcValue > balances[j].Balance.BtcValue
+	})
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Exchange", "Symbol", "Value", "BTC Value"})
@@ -99,7 +87,7 @@ func aggs(c *cli.Context) error {
 	return nil
 }
 
-func getBalances(ctx context.Context, c *cli.Context, exchange string, balances Balances) (Balances, error) {
+func getBalances(ctx context.Context, c *cli.Context, exchange string, balances []Balance) ([]Balance, error) {
 	if s := c.String(exchange); s != "" {
 		key, secret, err := parseKey(s)
 		if err != nil {


### PR DESCRIPTION
- Support multiple accounts for each exchange with using the flag repeatedly.
- Support changing sorting method by `-sort` flag, and it can take multiple.
- Use `sort.Slice` (go1.8+) instead of `sort.Sort`

and I combined multiple features into one PR, sorry!